### PR TITLE
Refactor GetResponseAndLogStepsAsync return type

### DIFF
--- a/NDJH.Hypixel.API/HttpDeserializerService.cs
+++ b/NDJH.Hypixel.API/HttpDeserializerService.cs
@@ -30,10 +30,13 @@ public class HttpDeserializerService(
         await rateLimitService.WaitForRateLimitAsync(cancellationToken);
         var (content, statusCode) = await GetResponseAndLogStepsAsync(url, cancellationToken);
 
+        // Serialize to ApiError and handle any errors
         var errorData = ReadAndDeserializeDataAsync<ApiErrorModel>(content);
         HandleErrorStatusCode(statusCode, errorData);
 
         logger.LogTrace("Received {Path} response. Deserializing", url);
+
+        // Serialize to requested object and return
         var data = ReadAndDeserializeDataAsync<TResponse>(content);
         return data;
     }
@@ -42,6 +45,7 @@ public class HttpDeserializerService(
         CancellationToken cancellationToken)
     {
         logger.LogTrace("Requesting to {Path}.", url);
+        // Making and reading response
         var response = await httpClient.GetAsync(url, cancellationToken);
         var content = await response.Content.ReadAsStringAsync(cancellationToken);
         logger.LogTrace("Hypixel returned an {StatusCode} with the response of: {Response}", response.StatusCode,
@@ -54,7 +58,7 @@ public class HttpDeserializerService(
         return (content, response.StatusCode);
     }
 
-    private void SetRemainingLimits(HttpResponseHeaders headers)
+    private void SetRemainingLimits(HttpHeaders headers)
     {
         var remainingRequests = 0;
         var resetTime = new DateTime();


### PR DESCRIPTION
## Description
[//]: # (Summarize the problem the PR addresses or the feature it introduces. This should be at least a few sentences but be detailed enough for a team member to understand._)

The return type of the GetResponseAndLogStepsAsync method has been refactored to return both content and status code. This change fixes the response content being read twice.

[//]: # (issue\(s\) number)
Fixes:

## Proposed Changes
[//]: # (Describe the big picture of your changes here. If it fixes a bug or resolves a feature request, be sure to link to that issue.)


## Additional Info
[//]: # (Add any other context or screenshots about the PR here.)



## Checklist
- [x] Tests
- [ ] Documentation
- [x] I have self-reviewed my code and corrected any misspellings
- [x] I have commented my code, particularly in hard-to-understand areas
- [x No new warnings are introduced
- [x] Existing tests pass
